### PR TITLE
feat: add GNOME 43/44 support, color thresholds, panel position and p…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .idx/dev.nix
 schemas/gschemas.compiled
 .idea
+dist/
+latency.zip
+latency-gnome43.zip
+latency-gnome45.zip

--- a/Makefile
+++ b/Makefile
@@ -7,24 +7,30 @@ EXTENSION_NAME = latency
 # Directories
 SCHEMAS_DIR = schemas
 INSTALL_DIR = $(HOME)/.local/share/gnome-shell/extensions/$(EXTENSION_UUID)
+DIST_DIR    = dist
 
-# Files to include in the extension
-EXTENSION_FILES = extension.js metadata.json prefs.js show-ping-time.sh LICENSE README.md
+# Common files shared across all versions
+COMMON_FILES = show-ping-time.sh LICENSE README.md
 SCHEMA_FILES = $(SCHEMAS_DIR)/org.gnome.shell.extensions.latency.gschema.xml
 COMPILED_SCHEMA = $(SCHEMAS_DIR)/gschemas.compiled
 
-.PHONY: help build install uninstall clean
+.PHONY: help build install uninstall clean check-deps check zip-gnome43 zip-gnome45 zip-all
 
 # Default target
 all: build
 
 help:
 	@echo "Available targets:"
-	@echo "  build      - Compile schemas and prepare the extension"
-	@echo "  install    - Install the extension to user directory"
-	@echo "  uninstall  - Remove the extension from user directory"
-	@echo "  clean      - Clean build artifacts"
-	@echo "  help       - Show this help message"
+	@echo "  build        - Compile schemas and prepare the extension"
+	@echo "  install      - Install for the current GNOME version"
+	@echo "  uninstall    - Remove the extension"
+	@echo "  zip-gnome43  - Build ZIP for GNOME 43/44 (extensions.gnome.org)"
+	@echo "  zip-gnome45  - Build ZIP for GNOME 45+  (extensions.gnome.org)"
+	@echo "  zip-all      - Build both ZIPs"
+	@echo "  clean        - Clean build artifacts"
+	@echo "  check-deps   - Check required dependencies"
+	@echo "  check        - Check extension structure"
+	@echo "  help         - Show this help message"
 
 build: $(COMPILED_SCHEMA)
 	@echo "Building extension..."
@@ -36,11 +42,23 @@ $(COMPILED_SCHEMA): $(SCHEMA_FILES)
 	@glib-compile-schemas $(SCHEMAS_DIR)/
 	@echo "Schemas compiled successfully!"
 
+# ─── Local install (auto-detects GNOME version) ──────────────────────────────
+
 install: build
 	@echo "Installing extension to $(INSTALL_DIR)..."
-	@mkdir -p $(INSTALL_DIR)
 	@mkdir -p $(INSTALL_DIR)/$(SCHEMAS_DIR)
-	@cp $(EXTENSION_FILES) $(INSTALL_DIR)/
+	@GNOME_VER=$$(gnome-shell --version 2>/dev/null | grep -oP '\d+' | head -1); \
+	if [ -n "$$GNOME_VER" ] && [ "$$GNOME_VER" -lt 45 ]; then \
+		echo "Detected GNOME $$GNOME_VER: installing GNOME 43/44 compatible files..."; \
+		cp extension.gnome43.js $(INSTALL_DIR)/extension.js; \
+		cp prefs.gnome43.js $(INSTALL_DIR)/prefs.js; \
+	else \
+		echo "Detected GNOME $$GNOME_VER: installing GNOME 45+ compatible files..."; \
+		cp extension.js $(INSTALL_DIR)/extension.js; \
+		cp prefs.js $(INSTALL_DIR)/prefs.js; \
+	fi
+	@cp metadata.json $(INSTALL_DIR)/
+	@cp $(COMMON_FILES) $(INSTALL_DIR)/
 	@cp $(SCHEMA_FILES) $(INSTALL_DIR)/$(SCHEMAS_DIR)/
 	@cp $(COMPILED_SCHEMA) $(INSTALL_DIR)/$(SCHEMAS_DIR)/
 	@echo "Extension installed successfully!"
@@ -58,23 +76,60 @@ uninstall:
 		echo "Extension not found in $(INSTALL_DIR)"; \
 	fi
 
+# ─── Distribution ZIPs for extensions.gnome.org ─────────────────────────────
+
+zip-gnome43: build
+	@echo "Building GNOME 43/44 ZIP..."
+	@rm -rf $(DIST_DIR)/gnome43 && mkdir -p $(DIST_DIR)/gnome43/$(SCHEMAS_DIR)
+	@cp extension.gnome43.js  $(DIST_DIR)/gnome43/extension.js
+	@cp prefs.gnome43.js      $(DIST_DIR)/gnome43/prefs.js
+	@cp $(COMMON_FILES)       $(DIST_DIR)/gnome43/
+	@cp $(SCHEMA_FILES)       $(DIST_DIR)/gnome43/$(SCHEMAS_DIR)/
+	@cp $(COMPILED_SCHEMA)    $(DIST_DIR)/gnome43/$(SCHEMAS_DIR)/
+	@python3 -c "import json; m=json.load(open('metadata.json')); m['shell-version']=['43','44']; json.dump(m, open('$(DIST_DIR)/gnome43/metadata.json','w'), indent=2); print('')"
+	@cd $(DIST_DIR)/gnome43 && zip -r ../../latency-gnome43.zip . -x "*.DS_Store"
+	@rm -rf $(DIST_DIR)/gnome43
+	@echo "Created latency-gnome43.zip"
+
+zip-gnome45: build
+	@echo "Building GNOME 45+ ZIP..."
+	@rm -rf $(DIST_DIR)/gnome45 && mkdir -p $(DIST_DIR)/gnome45/$(SCHEMAS_DIR)
+	@cp extension.js          $(DIST_DIR)/gnome45/extension.js
+	@cp prefs.js              $(DIST_DIR)/gnome45/prefs.js
+	@cp $(COMMON_FILES)       $(DIST_DIR)/gnome45/
+	@cp $(SCHEMA_FILES)       $(DIST_DIR)/gnome45/$(SCHEMAS_DIR)/
+	@cp $(COMPILED_SCHEMA)    $(DIST_DIR)/gnome45/$(SCHEMAS_DIR)/
+	@python3 -c "import json; m=json.load(open('metadata.json')); m['shell-version']=['45','46','47','48','49','50']; json.dump(m, open('$(DIST_DIR)/gnome45/metadata.json','w'), indent=2); print('')"
+	@cd $(DIST_DIR)/gnome45 && zip -r ../../latency-gnome45.zip . -x "*.DS_Store"
+	@rm -rf $(DIST_DIR)/gnome45
+	@echo "Created latency-gnome45.zip"
+
+zip-all: zip-gnome43 zip-gnome45
+	@echo ""
+	@echo "Both ZIPs ready for extensions.gnome.org:"
+	@echo "  latency-gnome43.zip  ->  upload for GNOME 43 and 44"
+	@echo "  latency-gnome45.zip  ->  upload for GNOME 45, 46, 47, 48, 49, 50"
+
+# ─── Utilities ───────────────────────────────────────────────────────────────
+
 clean:
 	@echo "Cleaning build artifacts..."
 	@rm -f $(COMPILED_SCHEMA)
+	@rm -rf $(DIST_DIR)
+	@rm -f latency-gnome43.zip latency-gnome45.zip
 	@echo "Clean completed!"
 
-# Check if required tools are available
 check-deps:
 	@echo "Checking dependencies..."
-	@command -v glib-compile-schemas >/dev/null 2>&1 || { echo "Error: glib-compile-schemas not found. Please install glib development packages."; exit 1; }
-	@command -v ping >/dev/null 2>&1 || { echo "Error: ping command not found."; exit 1; }
-	@command -v host >/dev/null 2>&1 || { echo "Error: host command not found."; exit 1; }
+	@command -v glib-compile-schemas >/dev/null 2>&1 || { echo "Error: glib-compile-schemas not found. Install: sudo apt install libglib2.0-dev"; exit 1; }
+	@command -v ping >/dev/null 2>&1 || { echo "Error: ping not found. Install: sudo apt install iputils-ping"; exit 1; }
+	@command -v host >/dev/null 2>&1 || { echo "Error: host not found. Install: sudo apt install bind9-host"; exit 1; }
+	@command -v python3 >/dev/null 2>&1 || { echo "Error: python3 not found."; exit 1; }
 	@echo "All dependencies are available!"
 
-# Development target to check the extension structure
 check:
 	@echo "Checking extension structure..."
-	@for file in $(EXTENSION_FILES); do \
+	@for file in extension.js prefs.js extension.gnome43.js prefs.gnome43.js metadata.json $(COMMON_FILES); do \
 		if [ ! -f "$$file" ]; then \
 			echo "Warning: $$file not found"; \
 		fi; \

--- a/README.md
+++ b/README.md
@@ -1,30 +1,42 @@
 # Latency - GNOME Shell Extension
 
-A GNOME Shell extension that displays internet latency (ping) in the top panel. It also shows when the internet connection is lost or if there is a DNS problem.
+A GNOME Shell extension that displays internet latency (ping) in the top panel. It also detects when the internet connection is lost or when there is a DNS problem.
 
 ## Features
 
-- Real-time latency display in the top panel
+- Real-time latency display in the top panel (updates every 5 seconds)
+- Color-coded indicator based on configurable thresholds (green / yellow / red)
+- Customizable colors for each state (normal, warning, critical)
+- Configurable panel position (left or right)
 - Configurable "Latency:" label (can be hidden to show only the ping value)
-- Automatic detection of connection issues
+- Automatic detection of connection loss
 - DNS problem detection
-- Uses Google's DNS (8.8.8.8) for reliable testing
+- Quick access to preferences by clicking the indicator
+- Customizable ping target IP and DNS resolve domain
+
+## GNOME Shell version support
+
+| GNOME version | Supported |
+|---|---|
+| 43, 44 | Yes |
+| 45, 46, 47, 48, 49, 50 | Yes |
 
 ## Prerequisites
 
 Before building and installing this extension, make sure you have the following installed:
 
-- GNOME Shell (version 48, 49, or 50)
-- `glib-compile-schemas` (usually part of `glib2-devel` or `libglib2.0-dev` package)
-- `make` (for using the Makefile)
-- `ping` command
-- `host` command (for DNS checking)
+- GNOME Shell 43 or later
+- `glib-compile-schemas` (part of `glib2-devel` or `libglib2.0-dev`)
+- `make`
+- `ping`
+- `host` (for DNS checking)
+- `python3` (used by the build system to generate distribution ZIPs)
 
-### Installing prerequisites on different distributions:
+### Installing prerequisites
 
 **Ubuntu/Debian:**
 ```bash
-sudo apt install glib2.0-dev make iputils-ping bind9-host
+sudo apt install libglib2.0-dev make iputils-ping bind9-host
 ```
 
 **Fedora/RHEL:**
@@ -37,116 +49,111 @@ sudo dnf install glib2-devel make iputils bind-utils
 sudo pacman -S glib2 make iputils bind
 ```
 
-## Building
+## Building and installing
 
-### Using Make (Recommended)
-
-1. Clone the repository:
 ```bash
 git clone https://github.com/mboscovich/latency.git
 cd latency
-```
-
-2. Build the extension:
-```bash
-make build
-```
-
-3. Install the extension:
-```bash
 make install
 ```
 
-### Manual Build
+`make install` automatically detects your GNOME Shell version and installs the appropriate files.
 
-If you prefer to build manually:
-
-1. Clone the repository:
-```bash
-git clone https://github.com/mboscovich/latency.git
-cd latency
-```
-
-2. Compile the GSettings schema:
-```bash
-glib-compile-schemas schemas/
-```
-
-3. Make the ping script executable:
-```bash
-chmod +x show-ping-time.sh
-```
-
-4. Copy the extension to your local extensions directory:
-```bash
-mkdir -p ~/.local/share/gnome-shell/extensions/latency@mboscovich.github.io/
-cp -r * ~/.local/share/gnome-shell/extensions/latency@mboscovich.github.io/
-```
-
-## Installation
-
-After building, you need to:
+After installing:
 
 1. **Restart GNOME Shell:**
-   - On X11: Press `Alt + F2`, type `r`, and press Enter
-   - On Wayland: Log out and log back in
+   - X11: `Alt + F2` → type `r` → Enter
+   - Wayland: log out and log back in
 
 2. **Enable the extension:**
-   - Using GNOME Extensions app
-   - Or via command line: `gnome-extensions enable latency@mboscovich.github.io`
+```bash
+gnome-extensions enable latency@mboscovich.github.io
+```
 
 ## Configuration
 
-The extension includes a preferences window where you can:
+Click the indicator in the panel to open a menu, then select **Preferences**.
 
-- **Show/Hide "Latency" Label**: Toggle whether to display the word "Latency:" before the ping value
-
-To access preferences:
-- Open GNOME Extensions app and click the settings icon for the Latency extension
+Alternatively:
+- Open the GNOME Extensions app and click the settings icon for Latency
 - Or run: `gnome-extensions prefs latency@mboscovich.github.io`
+
+### Display
+
+| Setting | Description |
+|---|---|
+| Show "Latency" Label | Toggle the `Latency:` prefix before the ping value |
+| Panel Position | Place the indicator on the **Left** or **Right** side of the panel |
+
+### Connection
+
+| Setting | Default | Description |
+|---|---|---|
+| IP WAN Address | `8.8.8.8` | IP used for the ping check |
+| Resolve Domain | `google.com` | Domain used for the DNS check |
+
+### Color thresholds
+
+| Setting | Default | Description |
+|---|---|---|
+| Warning threshold | `100` ms | Above this value the indicator turns the warning color |
+| Critical threshold | `300` ms | Above this value the indicator turns the critical color |
+
+### Colors
+
+| Setting | Default | Description |
+|---|---|---|
+| Normal color | White | Latency is below the warning threshold |
+| Warning color | Yellow | Latency is between warning and critical thresholds |
+| Critical color | Red | Latency is above the critical threshold |
+
+When the connection is lost or there is a DNS problem, the indicator reverts to the default panel text color.
 
 ## Usage
 
-Once installed and enabled, the extension will:
+Once installed and enabled, the extension shows in the panel and updates every 5 seconds:
 
-1. Display the current latency in the top panel (updates every 5 seconds)
-2. Show `[ No internet connection ]` when offline
-3. Show `[ DNS Problem ]` when there are DNS resolution issues
-4. Display the ping time in milliseconds (e.g., "29.4ms" or "Latency: 29.4ms")
+| Display | Meaning |
+|---|---|
+| `29.4ms` | Current latency (colored based on thresholds) |
+| `Latency: 29.4ms` | Same, with label prefix enabled |
+| `[ No internet connection ]` | Ping failed |
+| `[ DNS Problem ]` | Ping succeeded but DNS resolution failed |
 
-## Development
+## Makefile targets
 
-### Makefile Targets
-
-- `make build` - Compile schemas and prepare the extension
-- `make install` - Install the extension to the user directory
-- `make uninstall` - Remove the extension from the user directory
-- `make clean` - Clean build artifacts
-- `make help` - Show available targets
+| Target | Description |
+|---|---|
+| `make build` | Compile schemas and prepare the extension |
+| `make install` | Install for the current GNOME version (auto-detected) |
+| `make uninstall` | Remove the extension |
+| `make zip-gnome43` | Build ZIP for GNOME 43/44 (for extensions.gnome.org) |
+| `make zip-gnome45` | Build ZIP for GNOME 45+ (for extensions.gnome.org) |
+| `make zip-all` | Build both ZIPs |
+| `make clean` | Remove build artifacts and ZIPs |
+| `make check-deps` | Verify all required tools are installed |
 
 ## Troubleshooting
 
-### Schema compilation error
-If you get a schema-related error, make sure to compile the schemas:
+**Schema error on startup:**
 ```bash
 glib-compile-schemas schemas/
 ```
 
-### Permission denied on ping script
-Make sure the ping script is executable:
+**Permission denied on ping script:**
 ```bash
 chmod +x show-ping-time.sh
 ```
 
-### Extension not appearing
-1. Make sure GNOME Shell has been restarted
-2. Check if the extension is enabled: `gnome-extensions list --enabled`
+**Extension not appearing after install:**
+1. Restart GNOME Shell (see above)
+2. Check it is enabled: `gnome-extensions list --enabled`
 3. Check for errors: `journalctl -f -o cat /usr/bin/gnome-shell`
 
 ## License
 
-This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version.
+GNU General Public License v2.0 or later. See [LICENSE](LICENSE) for details.
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions are welcome. Feel free to open a Pull Request or an issue.

--- a/createZip.sh
+++ b/createZip.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+zip -r latency.zip . \
+  -x "./.git/*" \
+  -x "./.github/*" \
+  -x "./.gitignore" \
+  -x "./Makefile" \
+  -x "./createZip.sh" \
+  -x "./latency.zip"

--- a/extension.gnome43.js
+++ b/extension.gnome43.js
@@ -1,4 +1,4 @@
-/* extension.js
+/* extension.js - GNOME 43/44 compatible (legacy imports API)
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,16 +16,11 @@
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
-import GObject from "gi://GObject";
-import GLib from "gi://GLib";
-import Gio from "gi://Gio";
-import Clutter from "gi://Clutter";
-import St from "gi://St";
-
-import * as Main from "resource:///org/gnome/shell/ui/main.js";
-import * as PanelMenu from "resource:///org/gnome/shell/ui/panelMenu.js";
-import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
-import {Extension} from "resource:///org/gnome/shell/extensions/extension.js";
+const {GObject, GLib, Gio, Clutter, St} = imports.gi;
+const Main = imports.ui.main;
+const PanelMenu = imports.ui.panelMenu;
+const PopupMenu = imports.ui.popupMenu;
+const ExtensionUtils = imports.misc.extensionUtils;
 
 const refreshInterval = 5;
 
@@ -56,17 +51,21 @@ const Indicator = GObject.registerClass(
     }
 );
 
-export default class Latency extends Extension {
-    constructor(metadata) {
-        super(metadata);
+class Latency {
+    constructor() {
         this._indicator = null;
         this._timeout = null;
         this._settings = null;
+        this._extensionPath = null;
+        this._uuid = null;
         this._positionChangedId = null;
     }
 
     enable() {
-        this._settings = this.getSettings();
+        const extension = ExtensionUtils.getCurrentExtension();
+        this._extensionPath = extension.path;
+        this._uuid = extension.uuid;
+        this._settings = ExtensionUtils.getSettings();
 
         this._positionChangedId = this._settings.connect(
             'changed::latency-position', () => this._createIndicator()
@@ -107,12 +106,12 @@ export default class Latency extends Extension {
         const box = position === 'right' ? 'right' : 'left';
         const pos = position === 'right' ? 0 : 1;
 
-        this._indicator = new Indicator(() => this.openPreferences());
-        Main.panel.addToStatusArea(this.uuid, this._indicator, pos, box);
+        this._indicator = new Indicator(() => ExtensionUtils.openPrefs());
+        Main.panel.addToStatusArea(this._uuid, this._indicator, pos, box);
     }
 
     getCurrentLatency() {
-        const scriptArgs = [`${this.path}/show-ping-time.sh`];
+        const scriptArgs = [`${this._extensionPath}/show-ping-time.sh`];
 
         const ipWanAddress = this._settings.get_string('latency-ip-wan').trim();
         if (ipWanAddress.length > 0)
@@ -173,4 +172,8 @@ export default class Latency extends Extension {
             this._indicator.setText('Error');
         }
     }
+}
+
+function init() {
+    return new Latency();
 }

--- a/prefs.gnome43.js
+++ b/prefs.gnome43.js
@@ -1,0 +1,195 @@
+/* prefs.js - GNOME 43/44 compatible (legacy imports API)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+const {Adw, Gtk, Gdk, Gio} = imports.gi;
+const ExtensionUtils = imports.misc.extensionUtils;
+
+const DEFAULT_WAN_IP         = '8.8.8.8';
+const DEFAULT_RESOLVE_DOMAIN = 'google.com';
+const POSITION_VALUES        = ['left', 'right'];
+
+// Convert Gdk.RGBA to hex string (#rrggbb)
+function _rgbaToHex(rgba) {
+    const r = Math.round(rgba.red   * 255).toString(16).padStart(2, '0');
+    const g = Math.round(rgba.green * 255).toString(16).padStart(2, '0');
+    const b = Math.round(rgba.blue  * 255).toString(16).padStart(2, '0');
+    return `#${r}${g}${b}`;
+}
+
+// Build an ActionRow with a ColorButton suffix bound to a GSettings string key
+function _makeColorRow(title, subtitle, settingKey, settings) {
+    const row = new Adw.ActionRow({title, subtitle});
+
+    const button = new Gtk.ColorButton({
+        valign: Gtk.Align.CENTER,
+        use_alpha: false,
+    });
+
+    const rgba = new Gdk.RGBA();
+    rgba.parse(settings.get_string(settingKey));
+    button.set_rgba(rgba);
+
+    button.connect('color-set', () => {
+        settings.set_string(settingKey, _rgbaToHex(button.get_rgba()));
+    });
+    settings.connect(`changed::${settingKey}`, () => {
+        const updated = new Gdk.RGBA();
+        updated.parse(settings.get_string(settingKey));
+        button.set_rgba(updated);
+    });
+
+    row.add_suffix(button);
+    return row;
+}
+
+function init() {}
+
+function fillPreferencesWindow(window) {
+    const settings = ExtensionUtils.getSettings();
+
+    const page = new Adw.PreferencesPage({
+        title: 'General',
+        icon_name: 'dialog-information-symbolic',
+    });
+    window.add(page);
+
+    // ── Display group ───────────────────────────────────────────────────────
+    const displayGroup = new Adw.PreferencesGroup({title: 'Display'});
+    page.add(displayGroup);
+
+    // Adw.SwitchRow requires libadwaita 1.4 (GNOME 45+).
+    // Use Adw.ActionRow + Gtk.Switch for GNOME 43/44 compatibility.
+    const latencyLabelRow = new Adw.ActionRow({
+        title: 'Show "Latency" Label',
+        subtitle: 'Display the word "Latency:" before the ping value',
+    });
+    const latencyLabelSwitch = new Gtk.Switch({valign: Gtk.Align.CENTER});
+    latencyLabelRow.add_suffix(latencyLabelSwitch);
+    latencyLabelRow.activatable_widget = latencyLabelSwitch;
+    displayGroup.add(latencyLabelRow);
+    settings.bind('show-latency-label', latencyLabelSwitch, 'active', Gio.SettingsBindFlags.DEFAULT);
+
+    // Position combo row (Adw.ComboRow available since libadwaita 1.0)
+    // Note: Gtk.StringList({strings:[...]}) constructor not available in GTK 4.8 (GNOME 43).
+    const positionModel = new Gtk.StringList();
+    positionModel.append('Left');
+    positionModel.append('Right');
+    const positionRow = new Adw.ComboRow({
+        title: 'Panel Position',
+        subtitle: 'Where to show the indicator in the panel',
+        model: positionModel,
+    });
+    positionRow.selected = Math.max(0, POSITION_VALUES.indexOf(
+        settings.get_string('latency-position')
+    ));
+    positionRow.connect('notify::selected', () => {
+        settings.set_string('latency-position', POSITION_VALUES[positionRow.selected]);
+    });
+    settings.connect('changed::latency-position', () => {
+        positionRow.selected = Math.max(0, POSITION_VALUES.indexOf(
+            settings.get_string('latency-position')
+        ));
+    });
+    displayGroup.add(positionRow);
+
+    // ── Connection group ────────────────────────────────────────────────────
+    const connectionGroup = new Adw.PreferencesGroup({title: 'Connection'});
+    page.add(connectionGroup);
+
+    const ipWan = new Adw.EntryRow({
+        title: 'IP WAN Address',
+        text: settings.get_string('latency-ip-wan') || DEFAULT_WAN_IP,
+    });
+    connectionGroup.add(ipWan);
+    settings.bind('latency-ip-wan', ipWan, 'text', Gio.SettingsBindFlags.DEFAULT);
+
+    const resolveDomain = new Adw.EntryRow({
+        title: 'Resolve Domain',
+        text: settings.get_string('latency-resolve-domain') || DEFAULT_RESOLVE_DOMAIN,
+    });
+    connectionGroup.add(resolveDomain);
+    settings.bind('latency-resolve-domain', resolveDomain, 'text', Gio.SettingsBindFlags.DEFAULT);
+
+    // ── Thresholds group ────────────────────────────────────────────────────
+    // Adw.SpinRow requires libadwaita 1.4 (GNOME 45+).
+    // Use Adw.ActionRow + Gtk.SpinButton for GNOME 43/44 compatibility.
+    const thresholdGroup = new Adw.PreferencesGroup({
+        title: 'Color Thresholds',
+        description: 'Latency is shown in green below warning, yellow below critical, red above critical',
+    });
+    page.add(thresholdGroup);
+
+    const warningRow = new Adw.ActionRow({
+        title: 'Warning threshold (ms)',
+        subtitle: 'Above this value the indicator turns yellow',
+    });
+    const warningSpinner = new Gtk.SpinButton({
+        adjustment: new Gtk.Adjustment({
+            lower: 1, upper: 10000, step_increment: 10, page_increment: 50,
+            value: settings.get_int('latency-threshold-warning'),
+        }),
+        valign: Gtk.Align.CENTER,
+        digits: 0,
+    });
+    warningRow.add_suffix(warningSpinner);
+    warningSpinner.connect('value-changed', () => {
+        settings.set_int('latency-threshold-warning', warningSpinner.get_value_as_int());
+    });
+    settings.connect('changed::latency-threshold-warning', () => {
+        warningSpinner.value = settings.get_int('latency-threshold-warning');
+    });
+    thresholdGroup.add(warningRow);
+
+    const criticalRow = new Adw.ActionRow({
+        title: 'Critical threshold (ms)',
+        subtitle: 'Above this value the indicator turns red',
+    });
+    const criticalSpinner = new Gtk.SpinButton({
+        adjustment: new Gtk.Adjustment({
+            lower: 1, upper: 10000, step_increment: 10, page_increment: 50,
+            value: settings.get_int('latency-threshold-critical'),
+        }),
+        valign: Gtk.Align.CENTER,
+        digits: 0,
+    });
+    criticalRow.add_suffix(criticalSpinner);
+    criticalSpinner.connect('value-changed', () => {
+        settings.set_int('latency-threshold-critical', criticalSpinner.get_value_as_int());
+    });
+    settings.connect('changed::latency-threshold-critical', () => {
+        criticalSpinner.value = settings.get_int('latency-threshold-critical');
+    });
+    thresholdGroup.add(criticalRow);
+
+    // ── Colors group ────────────────────────────────────────────────────────
+    const colorGroup = new Adw.PreferencesGroup({title: 'Colors'});
+    page.add(colorGroup);
+
+    colorGroup.add(_makeColorRow(
+        'Normal color', 'Shown when latency is below the warning threshold',
+        'latency-color-ok', settings
+    ));
+    colorGroup.add(_makeColorRow(
+        'Warning color', 'Shown when latency is between warning and critical thresholds',
+        'latency-color-warning', settings
+    ));
+    colorGroup.add(_makeColorRow(
+        'Critical color', 'Shown when latency is above the critical threshold',
+        'latency-color-critical', settings
+    ));
+}

--- a/prefs.js
+++ b/prefs.js
@@ -1,71 +1,159 @@
 import Gio from 'gi://Gio';
 import Adw from 'gi://Adw';
 import Gtk from 'gi://Gtk';
+import Gdk from 'gi://Gdk';
 
-import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/shell/extensions/prefs.js';
 
-const DEFAULT_WAN_IP = '8.8.8.8';
+const DEFAULT_WAN_IP         = '8.8.8.8';
 const DEFAULT_RESOLVE_DOMAIN = 'google.com';
+const POSITION_VALUES        = ['left', 'right'];
+
+// Convert Gdk.RGBA to hex string (#rrggbb)
+function _rgbaToHex(rgba) {
+    const r = Math.round(rgba.red   * 255).toString(16).padStart(2, '0');
+    const g = Math.round(rgba.green * 255).toString(16).padStart(2, '0');
+    const b = Math.round(rgba.blue  * 255).toString(16).padStart(2, '0');
+    return `#${r}${g}${b}`;
+}
+
+// Build an ActionRow with a ColorButton suffix bound to a GSettings string key
+function _makeColorRow(title, subtitle, settingKey, settings) {
+    const row = new Adw.ActionRow({title, subtitle});
+
+    const button = new Gtk.ColorButton({
+        valign: Gtk.Align.CENTER,
+        use_alpha: false,
+    });
+
+    const rgba = new Gdk.RGBA();
+    rgba.parse(settings.get_string(settingKey));
+    button.set_rgba(rgba);
+
+    button.connect('color-set', () => {
+        settings.set_string(settingKey, _rgbaToHex(button.get_rgba()));
+    });
+    settings.connect(`changed::${settingKey}`, () => {
+        const updated = new Gdk.RGBA();
+        updated.parse(settings.get_string(settingKey));
+        button.set_rgba(updated);
+    });
+
+    row.add_suffix(button);
+    return row;
+}
 
 export default class LatencyPreferences extends ExtensionPreferences {
     fillPreferencesWindow(window) {
-    const _settings = this.getSettings();
+        const settings = this.getSettings();
 
-        // Create a preferences page, with a single group
         const page = new Adw.PreferencesPage({
             title: _('General'),
             icon_name: 'dialog-information-symbolic',
         });
         window.add(page);
 
-        const group = new Adw.PreferencesGroup({
-            title: _('Display Options'),
-            description: _('Configure how latency information is displayed'),
-        });
-        page.add(group);
+        // ── Display group ───────────────────────────────────────────────────
+        const displayGroup = new Adw.PreferencesGroup({title: _('Display')});
+        page.add(displayGroup);
 
-        // Create a new preferences row
         const latencyLabel = new Adw.SwitchRow({
             title: _('Show "Latency" Label'),
             subtitle: _('Display the word "Latency:" before the ping value'),
         });
-        group.add(latencyLabel);
+        displayGroup.add(latencyLabel);
+        settings.bind('show-latency-label', latencyLabel, 'active', Gio.SettingsBindFlags.DEFAULT);
+
+        const positionRow = new Adw.ComboRow({
+            title: _('Panel Position'),
+            subtitle: _('Where to show the indicator in the panel'),
+            model: new Gtk.StringList({strings: [_('Left'), _('Right')]}),
+        });
+        positionRow.selected = Math.max(0, POSITION_VALUES.indexOf(
+            settings.get_string('latency-position')
+        ));
+        positionRow.connect('notify::selected', () => {
+            settings.set_string('latency-position', POSITION_VALUES[positionRow.selected]);
+        });
+        settings.connect('changed::latency-position', () => {
+            positionRow.selected = Math.max(0, POSITION_VALUES.indexOf(
+                settings.get_string('latency-position')
+            ));
+        });
+        displayGroup.add(positionRow);
+
+        // ── Connection group ────────────────────────────────────────────────
+        const connectionGroup = new Adw.PreferencesGroup({title: _('Connection')});
+        page.add(connectionGroup);
 
         const ipWan = new Adw.EntryRow({
             title: _('IP WAN Address'),
-            text: _settings.get_string('latency-ip-wan') || DEFAULT_WAN_IP,
+            text: settings.get_string('latency-ip-wan') || DEFAULT_WAN_IP,
         });
-        group.add(ipWan);
+        connectionGroup.add(ipWan);
+        settings.bind('latency-ip-wan', ipWan, 'text', Gio.SettingsBindFlags.DEFAULT);
 
         const resolveDomain = new Adw.EntryRow({
             title: _('Resolve Domain'),
-            text: _settings.get_string('latency-resolve-domain') || DEFAULT_RESOLVE_DOMAIN,
+            text: settings.get_string('latency-resolve-domain') || DEFAULT_RESOLVE_DOMAIN,
         });
-        group.add(resolveDomain);
+        connectionGroup.add(resolveDomain);
+        settings.bind('latency-resolve-domain', resolveDomain, 'text', Gio.SettingsBindFlags.DEFAULT);
 
-        // Create a settings object
-        window._settings = this.getSettings();
+        // ── Thresholds group ────────────────────────────────────────────────
+        const thresholdGroup = new Adw.PreferencesGroup({
+            title: _('Color Thresholds'),
+            description: _('Latency is shown in green below warning, yellow below critical, red above critical'),
+        });
+        page.add(thresholdGroup);
 
-        // Bind the switch to our `show-latency-label` key
-        window._settings.bind(
-            'show-latency-label',
-            latencyLabel,
-            'active',
-            Gio.SettingsBindFlags.DEFAULT
-        );
+        const warningRow = new Adw.SpinRow({
+            title: _('Warning threshold (ms)'),
+            subtitle: _('Above this value the indicator turns the warning color'),
+            adjustment: new Gtk.Adjustment({
+                lower: 1, upper: 10000, step_increment: 10, page_increment: 50,
+            }),
+        });
+        warningRow.value = settings.get_int('latency-threshold-warning');
+        warningRow.connect('notify::value', () => {
+            settings.set_int('latency-threshold-warning', warningRow.value);
+        });
+        settings.connect('changed::latency-threshold-warning', () => {
+            warningRow.value = settings.get_int('latency-threshold-warning');
+        });
+        thresholdGroup.add(warningRow);
 
-        // Bind the entry rows to their respective GSettings keys
-        window._settings.bind(
-            'latency-ip-wan',
-            ipWan,
-            'text',
-            Gio.SettingsBindFlags.DEFAULT
-        );
-        window._settings.bind(
-            'latency-resolve-domain',
-            resolveDomain,
-            'text',
-            Gio.SettingsBindFlags.DEFAULT
-        );
+        const criticalRow = new Adw.SpinRow({
+            title: _('Critical threshold (ms)'),
+            subtitle: _('Above this value the indicator turns the critical color'),
+            adjustment: new Gtk.Adjustment({
+                lower: 1, upper: 10000, step_increment: 10, page_increment: 50,
+            }),
+        });
+        criticalRow.value = settings.get_int('latency-threshold-critical');
+        criticalRow.connect('notify::value', () => {
+            settings.set_int('latency-threshold-critical', criticalRow.value);
+        });
+        settings.connect('changed::latency-threshold-critical', () => {
+            criticalRow.value = settings.get_int('latency-threshold-critical');
+        });
+        thresholdGroup.add(criticalRow);
+
+        // ── Colors group ────────────────────────────────────────────────────
+        const colorGroup = new Adw.PreferencesGroup({title: _('Colors')});
+        page.add(colorGroup);
+
+        colorGroup.add(_makeColorRow(
+            _('Normal color'), _('Shown when latency is below the warning threshold'),
+            'latency-color-ok', settings
+        ));
+        colorGroup.add(_makeColorRow(
+            _('Warning color'), _('Shown when latency is between warning and critical thresholds'),
+            'latency-color-warning', settings
+        ));
+        colorGroup.add(_makeColorRow(
+            _('Critical color'), _('Shown when latency is above the critical threshold'),
+            'latency-color-critical', settings
+        ));
     }
 }

--- a/schemas/org.gnome.shell.extensions.latency.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.latency.gschema.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
   <schema id="org.gnome.shell.extensions.latency" path="/org/gnome/shell/extensions/latency/">
+
     <key name="show-latency-label" type="b">
       <default>true</default>
       <summary>Show "Latency" label</summary>
@@ -18,5 +19,48 @@
       <summary>Resolve Domain</summary>
       <description>The domain to resolve to detect DNS failures</description>
     </key>
+
+    <key name="latency-position" type="s">
+      <choices>
+        <choice value="left"/>
+        <choice value="right"/>
+      </choices>
+      <default>'left'</default>
+      <summary>Panel position</summary>
+      <description>Position of the indicator in the panel: 'left' or 'right'</description>
+    </key>
+
+    <key name="latency-threshold-warning" type="i">
+      <default>100</default>
+      <range min="1" max="10000"/>
+      <summary>Warning threshold in milliseconds</summary>
+      <description>Latency above this value (ms) will be shown in yellow</description>
+    </key>
+
+    <key name="latency-threshold-critical" type="i">
+      <default>300</default>
+      <range min="1" max="10000"/>
+      <summary>Critical threshold in milliseconds</summary>
+      <description>Latency above this value (ms) will be shown in red</description>
+    </key>
+
+    <key name="latency-color-ok" type="s">
+      <default>'#ffffff'</default>
+      <summary>Color for normal latency</summary>
+      <description>Hex color shown when latency is below the warning threshold</description>
+    </key>
+
+    <key name="latency-color-warning" type="s">
+      <default>'#f5c211'</default>
+      <summary>Color for warning latency</summary>
+      <description>Hex color shown when latency is between warning and critical thresholds</description>
+    </key>
+
+    <key name="latency-color-critical" type="s">
+      <default>'#e01b24'</default>
+      <summary>Color for critical latency</summary>
+      <description>Hex color shown when latency is above the critical threshold</description>
+    </key>
+
   </schema>
 </schemalist>


### PR DESCRIPTION
…references shortcut

  Add compatibility with GNOME 43/44 using the legacy imports API
  (extension.gnome43.js, prefs.gnome43.js). The Makefile auto-detects
  the installed GNOME version at install time and copies the appropriate
  files.

  New features:
  - Color-coded indicator based on configurable warning/critical thresholds
  - Customizable colors for each state (normal, warning, critical)
  - Configurable panel position (left/right), applied immediately
  - Click the indicator to open a Preferences menu item directly
  - Default normal color set to white

  Build system:
  - Add make zip-gnome43, zip-gnome45 and zip-all targets to generate distribution ZIPs ready for extensions.gnome.org
  - createZip.sh updated to exclude the output zip from itself

  Fix prefs.js import path (wrong casing caused preferences window to
  fail on GNOME 45+).

  Update README to document all new settings and GNOME version support.