### PR TITLE
feat: add configurable ping refresh interval setting

### DIFF
--- a/extension.gnome43.js
+++ b/extension.gnome43.js
@@ -22,8 +22,6 @@ const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const ExtensionUtils = imports.misc.extensionUtils;
 
-const refreshInterval = 5;
-
 const Indicator = GObject.registerClass(
     class Indicator extends PanelMenu.Button {
         _init(openPrefsCallback) {
@@ -59,6 +57,7 @@ class Latency {
         this._extensionPath = null;
         this._uuid = null;
         this._positionChangedId = null;
+        this._intervalChangedId = null;
     }
 
     enable() {
@@ -70,21 +69,22 @@ class Latency {
         this._positionChangedId = this._settings.connect(
             'changed::latency-position', () => this._createIndicator()
         );
+        this._intervalChangedId = this._settings.connect(
+            'changed::latency-refresh-interval', () => this._restartTimer()
+        );
 
         this._createIndicator();
-
-        this._timeout = GLib.timeout_add_seconds(
-            GLib.PRIORITY_DEFAULT, refreshInterval, () => {
-                this.getCurrentLatency();
-                return GLib.SOURCE_CONTINUE;
-            }
-        );
+        this._restartTimer();
     }
 
     disable() {
         if (this._positionChangedId) {
             this._settings.disconnect(this._positionChangedId);
             this._positionChangedId = null;
+        }
+        if (this._intervalChangedId) {
+            this._settings.disconnect(this._intervalChangedId);
+            this._intervalChangedId = null;
         }
         if (this._timeout != null) {
             GLib.source_remove(this._timeout);
@@ -95,6 +95,21 @@ class Latency {
             this._indicator = null;
         }
         this._settings = null;
+    }
+
+    _restartTimer() {
+        if (this._timeout != null) {
+            GLib.source_remove(this._timeout);
+            this._timeout = null;
+        }
+        const interval = this._settings.get_int('latency-refresh-interval');
+        this.getCurrentLatency();
+        this._timeout = GLib.timeout_add_seconds(
+            GLib.PRIORITY_DEFAULT, interval, () => {
+                this.getCurrentLatency();
+                return GLib.SOURCE_CONTINUE;
+            }
+        );
     }
 
     _createIndicator() {

--- a/extension.js
+++ b/extension.js
@@ -27,8 +27,6 @@ import * as PanelMenu from "resource:///org/gnome/shell/ui/panelMenu.js";
 import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
 import {Extension} from "resource:///org/gnome/shell/extensions/extension.js";
 
-const refreshInterval = 5;
-
 const Indicator = GObject.registerClass(
     class Indicator extends PanelMenu.Button {
         _init(openPrefsCallback) {
@@ -63,6 +61,7 @@ export default class Latency extends Extension {
         this._timeout = null;
         this._settings = null;
         this._positionChangedId = null;
+        this._intervalChangedId = null;
     }
 
     enable() {
@@ -71,21 +70,22 @@ export default class Latency extends Extension {
         this._positionChangedId = this._settings.connect(
             'changed::latency-position', () => this._createIndicator()
         );
+        this._intervalChangedId = this._settings.connect(
+            'changed::latency-refresh-interval', () => this._restartTimer()
+        );
 
         this._createIndicator();
-
-        this._timeout = GLib.timeout_add_seconds(
-            GLib.PRIORITY_DEFAULT, refreshInterval, () => {
-                this.getCurrentLatency();
-                return GLib.SOURCE_CONTINUE;
-            }
-        );
+        this._restartTimer();
     }
 
     disable() {
         if (this._positionChangedId) {
             this._settings.disconnect(this._positionChangedId);
             this._positionChangedId = null;
+        }
+        if (this._intervalChangedId) {
+            this._settings.disconnect(this._intervalChangedId);
+            this._intervalChangedId = null;
         }
         if (this._timeout != null) {
             GLib.source_remove(this._timeout);
@@ -96,6 +96,21 @@ export default class Latency extends Extension {
             this._indicator = null;
         }
         this._settings = null;
+    }
+
+    _restartTimer() {
+        if (this._timeout != null) {
+            GLib.source_remove(this._timeout);
+            this._timeout = null;
+        }
+        const interval = this._settings.get_int('latency-refresh-interval');
+        this.getCurrentLatency();
+        this._timeout = GLib.timeout_add_seconds(
+            GLib.PRIORITY_DEFAULT, interval, () => {
+                this.getCurrentLatency();
+                return GLib.SOURCE_CONTINUE;
+            }
+        );
     }
 
     _createIndicator() {

--- a/prefs.gnome43.js
+++ b/prefs.gnome43.js
@@ -125,6 +125,27 @@ function fillPreferencesWindow(window) {
     connectionGroup.add(resolveDomain);
     settings.bind('latency-resolve-domain', resolveDomain, 'text', Gio.SettingsBindFlags.DEFAULT);
 
+    const refreshIntervalRow = new Adw.ActionRow({
+        title: 'Refresh Interval (s)',
+        subtitle: 'How often to run the ping check',
+    });
+    const refreshSpinner = new Gtk.SpinButton({
+        adjustment: new Gtk.Adjustment({
+            lower: 1, upper: 3600, step_increment: 1, page_increment: 5,
+            value: settings.get_int('latency-refresh-interval'),
+        }),
+        valign: Gtk.Align.CENTER,
+        digits: 0,
+    });
+    refreshIntervalRow.add_suffix(refreshSpinner);
+    refreshSpinner.connect('value-changed', () => {
+        settings.set_int('latency-refresh-interval', refreshSpinner.get_value_as_int());
+    });
+    settings.connect('changed::latency-refresh-interval', () => {
+        refreshSpinner.value = settings.get_int('latency-refresh-interval');
+    });
+    connectionGroup.add(refreshIntervalRow);
+
     // ── Thresholds group ────────────────────────────────────────────────────
     // Adw.SpinRow requires libadwaita 1.4 (GNOME 45+).
     // Use Adw.ActionRow + Gtk.SpinButton for GNOME 43/44 compatibility.

--- a/prefs.js
+++ b/prefs.js
@@ -100,6 +100,22 @@ export default class LatencyPreferences extends ExtensionPreferences {
         connectionGroup.add(resolveDomain);
         settings.bind('latency-resolve-domain', resolveDomain, 'text', Gio.SettingsBindFlags.DEFAULT);
 
+        const refreshIntervalRow = new Adw.SpinRow({
+            title: _('Refresh Interval (s)'),
+            subtitle: _('How often to run the ping check'),
+            adjustment: new Gtk.Adjustment({
+                lower: 1, upper: 3600, step_increment: 1, page_increment: 5,
+            }),
+        });
+        refreshIntervalRow.value = settings.get_int('latency-refresh-interval');
+        refreshIntervalRow.connect('notify::value', () => {
+            settings.set_int('latency-refresh-interval', refreshIntervalRow.value);
+        });
+        settings.connect('changed::latency-refresh-interval', () => {
+            refreshIntervalRow.value = settings.get_int('latency-refresh-interval');
+        });
+        connectionGroup.add(refreshIntervalRow);
+
         // ── Thresholds group ────────────────────────────────────────────────
         const thresholdGroup = new Adw.PreferencesGroup({
             title: _('Color Thresholds'),

--- a/schemas/org.gnome.shell.extensions.latency.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.latency.gschema.xml
@@ -62,5 +62,12 @@
       <description>Hex color shown when latency is above the critical threshold</description>
     </key>
 
+    <key name="latency-refresh-interval" type="i">
+      <default>5</default>
+      <range min="1" max="3600"/>
+      <summary>Refresh interval in seconds</summary>
+      <description>How often to run the ping check (in seconds)</description>
+    </key>
+
   </schema>
 </schemalist>


### PR DESCRIPTION
Add a new GSettings key `latency-refresh-interval` (integer, default 5s, range 1–3600s) that lets users control how often the ping runs. The timer is restarted immediately when the value changes in preferences, without needing to disable/enable the extension.

Updated both extension.js and extension.gnome43.js to use _restartTimer(), and added the corresponding spinner control to prefs.js (Adw.SpinRow for GNOME 45+) and prefs.gnome43.js (Adw.ActionRow + Gtk.SpinButton for GNOME 43/44).